### PR TITLE
feature: add autocomplete

### DIFF
--- a/examples/CRA/src/App.tsx
+++ b/examples/CRA/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {MapBox, OverlayView, TrafficLayer, SearchBox} from './lib'
+import {Autocomplete, MapBox, OverlayView, TrafficLayer, SearchBox} from './lib'
 import CenterButton from './components/CenterButton'
 import DrawingControl from './components/DrawingControl'
 import MarkerPanel from './components/MarkerPanel'
@@ -24,6 +24,20 @@ const App = () => {
         </h2>
       </OverlayView>
       <div className="Map">
+        <Autocomplete
+          id="autocomplete"
+          placeholder="Autocomplete..."
+          bindingPosition="TOP_CENTER"
+          opts={{
+            bounds: {
+              east: -73.98,
+              west: -73.985,
+              north: 40.706,
+              south: 40.702,
+            },
+            fields: ['address_components'],
+          }}
+        />
         <SearchBox
           id="search-box"
           placeholder="Search..."

--- a/packages/lib/index.ts
+++ b/packages/lib/index.ts
@@ -1,3 +1,7 @@
+export {default as Autocomplete} from './src/components/Autocomplete'
+export {
+  default as StandaloneAutocomplete,
+} from './src/components/StandaloneAutocomplete'
 export {default as BicyclingLayer} from './src/components/BicyclingLayer'
 export {default as Circle} from './src/components/Circle'
 export {default as CustomControl} from './src/components/CustomControl'

--- a/packages/lib/src/__test__helpers__/defineGlobalVariable.ts
+++ b/packages/lib/src/__test__helpers__/defineGlobalVariable.ts
@@ -206,6 +206,17 @@ class Rectangle {
   }
 }
 
+class Autocomplete {
+  opts?: google.maps.places.AutocompleteOptions
+  setOptions = (opts: google.maps.StreetViewPanoramaOptions) => {
+    this.opts = opts
+  }
+  constructor(
+    inputNode: HTMLInputElement,
+    opts?: google.maps.places.AutocompleteOptions,
+  ) {}
+}
+
 class SearchBox {
   bounds?: google.maps.LatLngBoundsLiteral
   setBounds = (bounds: google.maps.LatLngBoundsLiteral) => {
@@ -328,6 +339,7 @@ const defineGlobalVariable = () => {
           },
         },
         places: {
+          Autocomplete: Autocomplete,
           PlacesService: PlacesService,
           SearchBox: SearchBox,
         },

--- a/packages/lib/src/common/constants.ts
+++ b/packages/lib/src/common/constants.ts
@@ -80,6 +80,10 @@ export const DEFAULT_SEARCH_BOX_OPTIONS: google.maps.places.SearchBoxOptions = {
   bounds: NYC_RECTANGLE,
 }
 
+export const DEFAULT_AUTOCOMPLETE_OPTIONS: google.maps.places.AutocompleteOptions = {
+  bounds: NYC_RECTANGLE,
+}
+
 export const DEFAULT_STREET_VIEW_OPTIONS: google.maps.StreetViewPanoramaOptions = {
   position: NYC_LATLNG,
 }

--- a/packages/lib/src/common/types.ts
+++ b/packages/lib/src/common/types.ts
@@ -31,11 +31,13 @@ export declare type GoogleMapObjectWithSetOptions =
   | google.maps.StreetViewPanorama
   | google.maps.KmlLayer
   | google.maps.drawing.DrawingManager
+  | google.maps.places.Autocomplete
 
 export declare type GoogleMapObject =
   | GoogleMapObjectWithSetMap
   | google.maps.StreetViewPanorama
   | google.maps.places.SearchBox
+  | google.maps.places.Autocomplete
 
 declare type MapPanes =
   | 'floatPane'
@@ -267,7 +269,7 @@ export interface GroundOverlayProps {
   onDoubleClick?: (event: google.maps.MouseEvent) => any
 }
 
-// SearchBox
+// Autocomplete
 
 declare type ControlPositionName =
   | 'BOTTOM_CENTER'
@@ -282,6 +284,26 @@ declare type ControlPositionName =
   | 'TOP_CENTER'
   | 'TOP_LEFT'
   | 'TOP_RIGHT'
+
+export interface StandaloneAutocompleteProps
+  extends React.DetailedHTMLProps<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  > {
+  id?: string
+  opts?: google.maps.places.AutocompleteOptions
+  onPlaceChanged?: () => any
+}
+
+export interface BasicAutocompleteProps extends StandaloneAutocompleteProps {
+  bindingPosition?: ControlPositionName
+}
+
+export interface AutocompleteProps extends StandaloneAutocompleteProps {
+  bindingPosition: ControlPositionName
+}
+
+// SearchBox
 
 export interface StandaloneSearchBoxProps
   extends React.DetailedHTMLProps<

--- a/packages/lib/src/components/Autocomplete.md
+++ b/packages/lib/src/components/Autocomplete.md
@@ -1,0 +1,41 @@
+A wrapper around `google.maps.places.Autocomplete`.
+
+- `usePlaces` must be `true` in `MapBox`
+- `id` must be unique. If left out, uuid will be used.
+- `opts` specifies the options you want the rectangle to be created with.
+- `bindingPosition` specifies the position you want the search box to be placed
+  at. Possible options are:
+  - 'BOTTOM_CENTER'
+  - 'BOTTOM_LEFT'
+  - 'BOTTOM_RIGHT'
+  - 'LEFT_BOTTOM'
+  - 'LEFT_CENTER'
+  - 'LEFT_TOP'
+  - 'RIGHT_BOTTOM'
+  - 'RIGHT_CENTER'
+  - 'RIGHT_TOP'
+  - 'TOP_CENTER'
+  - 'TOP_LEFT'
+  - 'TOP_RIGHT'
+- `onPlaceChanged` is the event handler for the `place_changed` event.
+- And you can add any other props that apply to `<input></input>`
+
+A simple Autocomplete:
+
+```jsx
+import {GoogleMapProvider, MapBox, Autocomplete} from '@googlemap-react/core'
+;<GoogleMapProvider>
+  <MapBox
+    style={{
+      height: '50vh',
+      width: '100%',
+    }}
+    usePlaces
+  />
+  <Autocomplete
+    id="autocomplete"
+    placeholder="Search..."
+    bindingPosition="TOP_CENTER"
+  />
+</GoogleMapProvider>
+```

--- a/packages/lib/src/components/Autocomplete.tsx
+++ b/packages/lib/src/components/Autocomplete.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import {AutocompleteProps} from '../common/types'
+import BasicAutocomplete from './BasicAutocomplete'
+
+const Autocomplete = (props: AutocompleteProps) => (
+  <BasicAutocomplete {...props} />
+)
+
+Autocomplete.displayName = 'Autocomplete'
+
+export default Autocomplete

--- a/packages/lib/src/components/BasicAutocomplete.tsx
+++ b/packages/lib/src/components/BasicAutocomplete.tsx
@@ -1,0 +1,78 @@
+import React, {useContext, useEffect, useState} from 'react'
+import ReactDOMServer from 'react-dom/server'
+import uuid from 'uuid/v1'
+import {useGoogleListener, useMemoizedOptions} from '../hooks'
+import {DEFAULT_AUTOCOMPLETE_OPTIONS} from '../common/constants'
+import {BasicAutocompleteProps} from '../common/types'
+import {GoogleMapContext} from '../contexts/GoogleMapContext'
+
+const BasicAutocomplete = ({
+  id,
+  opts = DEFAULT_AUTOCOMPLETE_OPTIONS,
+  onPlaceChanged,
+  bindingPosition,
+  ...restProps
+}: BasicAutocompleteProps) => {
+  const {state, dispatch} = useContext(GoogleMapContext)
+  const [prevOpts, setPrevOpts] = useState('')
+  const [autocomplete, setAutocomplete] = useState<
+    google.maps.places.Autocomplete | undefined
+  >(undefined)
+  const [autocompleteId] = useState(id ? id : `autocomplete-${uuid()}`)
+  const [container] = useState(
+    document
+      .createRange()
+      .createContextualFragment(
+        ReactDOMServer.renderToString(
+          <input id={autocompleteId} {...restProps} />,
+        ),
+      ).firstElementChild,
+  )
+  const [lastBindingPosition, setLastBindingPosition] = useState(
+    bindingPosition,
+  )
+
+  const addAutocomplete = (autocomplete: google.maps.places.Autocomplete) =>
+    dispatch({type: 'add_object', object: autocomplete, id: autocompleteId})
+  const removeAutocomplete = () =>
+    dispatch({type: 'remove_object', id: autocompleteId})
+
+  // Create google.maps.places.Autocomplete
+  useEffect(() => {
+    if (state.map === undefined || state.places === undefined) return
+    const inputNode = (bindingPosition
+      ? container
+      : document.getElementById(autocompleteId)) as HTMLInputElement
+    const autocomplete = new google.maps.places.Autocomplete(inputNode, opts)
+    setAutocomplete(autocomplete)
+    addAutocomplete(autocomplete)
+    setPrevOpts(JSON.stringify(opts))
+    if (bindingPosition) {
+      if (bindingPosition !== lastBindingPosition) {
+        const last =
+          state.map.controls[google.maps.ControlPosition[lastBindingPosition!]]
+        const lastArray = last.getArray()
+        last.removeAt(lastArray.findIndex(element => element === container))
+        setLastBindingPosition(bindingPosition)
+      }
+      state.map.controls[google.maps.ControlPosition[bindingPosition]].push(
+        inputNode,
+      )
+    }
+    return () => removeAutocomplete()
+  }, [state.places, bindingPosition])
+
+  // Register google map event listeners
+  useGoogleListener(autocomplete, [
+    {name: 'place_changed', handler: onPlaceChanged},
+  ])
+
+  // Modify the google.maps.Autocomplete object when component props change
+  useMemoizedOptions(autocomplete, opts, prevOpts, setPrevOpts)
+
+  return bindingPosition ? null : <input id={autocompleteId} {...restProps} />
+}
+
+BasicAutocomplete.displayName = 'Autocomplete'
+
+export default BasicAutocomplete

--- a/packages/lib/src/components/StandaloneAutocomplete.md
+++ b/packages/lib/src/components/StandaloneAutocomplete.md
@@ -1,0 +1,25 @@
+It is just like `Autocomplete`, however, no `bindingPosition` is needed. It will
+not be placed on the map.
+
+A simple StandaloneAutocomplete:
+
+```jsx
+import {
+  GoogleMapProvider,
+  MapBox,
+  StandaloneAutocomplete,
+} from '@googlemap-react/core'
+;<GoogleMapProvider>
+  <MapBox
+    style={{
+      height: '50vh',
+      width: '100%',
+    }}
+    usePlaces
+  />
+  <StandaloneAutocomplete
+    id="standalone-autocomplete"
+    placeholder="Search..."
+  />
+</GoogleMapProvider>
+```

--- a/packages/lib/src/components/StandaloneAutocomplete.tsx
+++ b/packages/lib/src/components/StandaloneAutocomplete.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import BasicAutocomplete from './BasicAutocomplete'
+import {StandaloneAutocompleteProps} from '../common/types'
+
+const StandaloneAutocomplete = (props: StandaloneAutocompleteProps) => (
+  <BasicAutocomplete {...props} />
+)
+
+StandaloneAutocomplete.displayName = 'StandaloneAutocomplete'
+
+export default StandaloneAutocomplete

--- a/packages/lib/src/components/__tests__/Autocomplete.test.tsx
+++ b/packages/lib/src/components/__tests__/Autocomplete.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import '@testing-library/react/cleanup-after-each'
+import {render, wait, cleanup, act} from '@testing-library/react'
+import {GoogleMapProvider, MapBox, Autocomplete} from '../../..'
+import {defineGlobalVariable} from '../../__test__helpers__'
+
+defineGlobalVariable()
+
+describe('Autocomplete', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('can be rendered', async () => {
+    const {container, rerender} = render(
+      <GoogleMapProvider>
+        <MapBox apiKey="FAKE_KEY" usePlaces />
+        <Autocomplete bindingPosition="TOP_CENTER" />
+      </GoogleMapProvider>,
+    )
+    await wait(() => {
+      expect(container.innerHTML).not.toMatch('Loading...')
+    })
+    act(() => {
+      rerender(
+        <GoogleMapProvider>
+          <MapBox apiKey="FAKE_KEY" usePlaces />
+          <Autocomplete
+            bindingPosition="TOP_RIGHT"
+            opts={{
+              bounds: {
+                east: -73.98,
+                west: -73.985,
+                north: 40.706,
+                south: 40.702,
+              },
+              fields: ['address_components'],
+            }}
+          />
+        </GoogleMapProvider>,
+      )
+    })
+    act(() => {
+      rerender(
+        <GoogleMapProvider>
+          <MapBox apiKey="FAKE_KEY" usePlaces />
+        </GoogleMapProvider>,
+      )
+    })
+  })
+})

--- a/packages/lib/src/components/__tests__/StandaloneAutocomplete.test.tsx
+++ b/packages/lib/src/components/__tests__/StandaloneAutocomplete.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import '@testing-library/react/cleanup-after-each'
+import {render, wait, cleanup} from '@testing-library/react'
+import {GoogleMapProvider, MapBox, StandaloneAutocomplete} from '../../..'
+import {defineGlobalVariable} from '../../__test__helpers__'
+
+defineGlobalVariable()
+
+describe('StandaloneAutocomplete', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('can be rendered', async () => {
+    const {container} = render(
+      <GoogleMapProvider>
+        <MapBox apiKey="FAKE_KEY" usePlaces />
+        <StandaloneAutocomplete id="autocomplete" />
+      </GoogleMapProvider>,
+    )
+    await wait(() => {
+      expect(container.innerHTML).not.toMatch('Loading...')
+    })
+  })
+})

--- a/packages/lib/styleguide.config.js
+++ b/packages/lib/styleguide.config.js
@@ -38,7 +38,7 @@ module.exports = {
     },
     {
       name: 'Places',
-      components: './src/components/{SearchBox,StandaloneSearchBox}.tsx',
+      components: './src/components/{Autocomplete,StandaloneAutocomplete,SearchBox,StandaloneSearchBox}.tsx',
     },
     {
       name: 'Visualization',


### PR DESCRIPTION
# Description

Adds react component for google.maps.places.Autocomplete. The difference between SearchBox & Autocomplete is that by default SearchBox returns all the available data

> By default, when a user selects a place, SearchBox returns all of the available data fields for the selected place, and you will be billed accordingly. There is no way to constrain SearchBox requests to only return specific fields. To keep from requesting (and paying for) data that you don't need, use the Autocomplete widget instead.

For example, if you only interested in `address_components`, it's possible to define it in options for Autocomplete.

```jsx
 <Autocomplete
   id="autocomplete"
   placeholder="Search..."
   bindingPosition="TOP_CENTER"
   opts={
      fields: ["address_components"]
   }
 />
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Unit testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
